### PR TITLE
New relocation class rc-relative-cell

### DIFF
--- a/basis/compiler/constants/constants-docs.factor
+++ b/basis/compiler/constants/constants-docs.factor
@@ -20,6 +20,10 @@ HELP: rc-relative-arm64-bcond
 HELP: rc-absolute-arm64-movz
 { $description "Absolute address stored in bits 20:5 of an ARM64 instruction." } ;
 
+HELP: rc-relative-cell
+{ $description "Indicates that the relocation is a cell-sized relative address to an object in the VM." } ;
+
+
 HELP: rt-cards-offset
 { $description "Relocation offset type for the cards table." }
 { $see-also rel-cards-offset } ;
@@ -98,6 +102,7 @@ $nl
     rc-relative-arm64-branch
     rc-relative-arm64-bcond
     rc-absolute-arm64-movz
+    rc-relative-cell
 }
 "Relocation types:"
 { $subsections

--- a/basis/compiler/constants/constants.factor
+++ b/basis/compiler/constants/constants.factor
@@ -56,6 +56,7 @@ CONSTANT: rc-absolute-ppc-2/2/2/2 12
 CONSTANT: rc-relative-arm64-branch 13
 CONSTANT: rc-relative-arm64-bcond 14
 CONSTANT: rc-absolute-arm64-movz 15
+CONSTANT: rc-relative-cell
 
 CONSTANT: rt-dlsym 0
 CONSTANT: rt-entry-point 1

--- a/vm/instruction_operands.cpp
+++ b/vm/instruction_operands.cpp
@@ -76,6 +76,8 @@ fixnum instruction_operand::load_value(cell relative_to) {
              relative_to;
     case RC_ABSOLUTE_ARM64_MOVZ:
       return load_value_masked(rel_absolute_arm64_movz_mask, 5, 16, 0);
+    case RC_RELATIVE_CELL:
+      return *(cell*)(pointer - sizeof(cell));
     default:
       critical_error("Bad rel class", rel.klass());
       return 0;
@@ -163,6 +165,9 @@ void instruction_operand::store_value(fixnum absolute_value) {
       break;
     case RC_ABSOLUTE_ARM64_MOVZ:
       store_value_masked(absolute_value, rel_absolute_arm64_movz_mask, 0, 5);
+      break;
+    case RC_RELATIVE_CELL:
+      *(cell*)(pointer - sizeof(cell)) = relative_value;
       break;
     default:
       critical_error("Bad rel class", rel.klass());

--- a/vm/instruction_operands.hpp
+++ b/vm/instruction_operands.hpp
@@ -68,6 +68,8 @@ enum relocation_class {
   RC_RELATIVE_ARM64_BCOND,
   // Absolute address stored in bits 20:5 of an ARM64 instruction
   RC_ABSOLUTE_ARM64_MOVZ,
+  // relative address in a pointer-width location
+  RC_RELATIVE_CELL,
 };
 
 static const cell rel_absolute_ppc_2_mask = 0x0000ffff;


### PR DESCRIPTION
In light of the fact that we may need to return to Gifti-style relocations, I've created the rc-relative-cell relocation class to facilitate that. 